### PR TITLE
sink: Add support for publishing audio only streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "gst-plugin-opentok"
 version = "0.1.0"
-authors = ["Fernando Jimenez Moreno <fjimenez@igalia.com>", "Philippe Normand <philn@igalia.com>"]
+authors = [
+  "Fernando Jimenez Moreno <fjimenez@igalia.com>",
+  "Philippe Normand <philn@igalia.com>",
+]
 edition = "2021"
 description = "GStreamer plugin to allow publishing and subscribing to OpenTok audio and video streams"
 repository = "https://github.com/opentok-rust/gst-plugin-opentok"
@@ -13,11 +16,19 @@ readme = "README.md"
 [package.metadata.deb]
 name = "gst-plugin-opentok"
 assets = [
-  ["target/release/deps/libgstopentok.so", "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/", "644"],
-  ["target/release/gst-opentok-helper", "/usr/bin/", "755"],
+  [
+    "target/release/deps/libgstopentok.so",
+    "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/",
+    "644",
+  ],
+  [
+    "target/release/gst-opentok-helper",
+    "/usr/bin/",
+    "755",
+  ],
 ]
 depends = "$auto,libopentok,libc++1-7"
-systemd-units = { }
+systemd-units = {}
 
 [lib]
 name = "gstopentok"
@@ -45,7 +56,7 @@ ipc-channel = "0.15.0"
 log = "0.4.14"
 once_cell = "1.0"
 # FIXME: Update to upstream when it is released
-opentok = { git = "https://github.com/opentok-rust/opentok-rs.git", rev = "f09365e86774fd979c2265db46ca8ac679cf7ec3" }
+opentok = { git = "https://github.com/opentok-rust/opentok-rs.git", rev = "55936e0ea12a63a0c879dd1b9dc341d542742f2d" }
 serde = "1.0.130"
 signal-child = "1.0.3"
 signal-hook = "0.3.10"

--- a/src/opentoksink/imp.rs
+++ b/src/opentoksink/imp.rs
@@ -18,7 +18,7 @@ use gst::prelude::*;
 use gst::subclass::prelude::*;
 use once_cell::sync::Lazy;
 use opentok::audio_device::{AudioDevice, AudioSampleData};
-use opentok::publisher::{Publisher, PublisherCallbacks};
+use opentok::publisher::{Publisher, PublisherCallbacks, PublisherSettingsBuilder};
 use opentok::session::{Session, SessionCallbacks};
 use opentok::video_capturer::{VideoCapturer, VideoCapturerCallbacks, VideoCapturerSettings};
 use opentok::video_frame::VideoFrame;
@@ -291,8 +291,24 @@ impl OpenTokSink {
 
         gst::debug!(CAT, imp: self, "Initializing publisher");
 
-        // Even if we are only publishing audio for now, we need to add a video
-        // capturer, in case a video pad is requested at some point.
+        if self.video_sink.lock().unwrap().is_none() {
+            gst::info!(CAT, imp: self, "No video sink, not publishing video");
+
+            let publisher = Publisher::new_with_settings(
+                None,
+                PublisherSettingsBuilder::new()
+                    .name("opentoksink")
+                    .video_track(false)
+                    .build(),
+            );
+
+            *self.publisher.lock().unwrap() = Some(publisher);
+
+            gst::debug!(CAT, "Publisher created");
+
+            return;
+        }
+
         let credentials = &self.credentials;
         let published_stream_id = &self.published_stream_id;
         let video_sink = &self.video_sink;
@@ -763,8 +779,12 @@ impl ElementImpl for OpenTokSink {
         _name: Option<&str>,
         _caps: Option<&gst::Caps>,
     ) -> Option<gst::Pad> {
-        let stream_type: StreamType = template.name_template().into();
+        if self.obj().current_state() > gst::State::Ready {
+            gst::error!(CAT, "element pads can only be requested before starting");
+            return None;
+        }
 
+        let stream_type: StreamType = template.name_template().into();
         gst::debug!(
             CAT,
             imp: self,
@@ -820,7 +840,7 @@ impl ElementImpl for OpenTokSink {
         transition: gst::StateChange,
     ) -> Result<gst::StateChangeSuccess, gst::StateChangeError> {
         gst::debug!(CAT, imp: self, "State changed {:?}", transition);
-        if transition == gst::StateChange::NullToReady {
+        if transition == gst::StateChange::ReadyToPaused {
             async_std::task::block_on(
                 self.credentials
                     .lock()

--- a/src/opentoksrc/imp.rs
+++ b/src/opentoksrc/imp.rs
@@ -386,8 +386,6 @@ impl OpenTokSrc {
                 .load(Duration::from_secs(5)),
         )?;
 
-        pipe_opentok_to_gst_log();
-
         self.maybe_init_session().map_err(|error| anyhow!(error))
     }
 
@@ -675,6 +673,8 @@ impl ObjectSubclass for OpenTokSrc {
 impl ObjectImpl for OpenTokSrc {
     fn constructed(&self) {
         self.parent_constructed();
+
+        pipe_opentok_to_gst_log();
 
         self.obj()
             .set_suppressed_flags(gst::ElementFlags::SOURCE | gst::ElementFlags::SINK);


### PR DESCRIPTION
And do not allow requesting new pads when state > Ready.